### PR TITLE
Quote strings that contain invalid patterns, not all strings; Update with shlex.quote regexp.

### DIFF
--- a/shellescape.go
+++ b/shellescape.go
@@ -22,7 +22,7 @@ import (
 var pattern *regexp.Regexp
 
 func init() {
-	pattern = regexp.MustCompilePOSIX("[^a-zA-Z0-9_^@%+=:,./-]")
+	pattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
 }
 
 // Quote returns a shell-escaped version of the string s. The returned value

--- a/shellescape.go
+++ b/shellescape.go
@@ -22,7 +22,7 @@ import (
 var pattern *regexp.Regexp
 
 func init() {
-	pattern = regexp.MustCompilePOSIX("[a-zA-Z0-9_^@%+=:,./-]")
+	pattern = regexp.MustCompilePOSIX("[^a-zA-Z0-9_^@%+=:,./-]")
 }
 
 // Quote returns a shell-escaped version of the string s. The returned value

--- a/shellescape_test.go
+++ b/shellescape_test.go
@@ -47,3 +47,9 @@ func TestAllInvalid(t *testing.T) {
 	expected := `';${}'`
 	assertEqual(t, s, expected)
 }
+
+func TestCleanString(t *testing.T) {
+	s := shellescape.Quote("foo.example.com")
+	expected := `foo.example.com`
+	assertEqual(t, s, expected)
+}

--- a/shellescape_test.go
+++ b/shellescape_test.go
@@ -35,3 +35,15 @@ func TestUnquotedString(t *testing.T) {
 	expected := `'no quotes'`
 	assertEqual(t, s, expected)
 }
+
+func TestSingleInvalid(t *testing.T) {
+	s := shellescape.Quote(`;`)
+	expected := `';'`
+	assertEqual(t, s, expected)
+}
+
+func TestAllInvalid(t *testing.T) {
+	s := shellescape.Quote(`;${}`)
+	expected := `';${}'`
+	assertEqual(t, s, expected)
+}


### PR DESCRIPTION
Inspired by seeing https://github.com/chrissimpkins/shellescape/pull/2

This PR uses the same regexp as Python does, and adds tests that currently fail.