### PR TITLE
add QuoteCommand to quote a complete command

### DIFF
--- a/shellescape.go
+++ b/shellescape.go
@@ -37,3 +37,13 @@ func Quote(s string) string {
 
 	return s
 }
+
+// QuoteCommand returns a shell-escaped version of the slice of strings.
+// The returned value is a string that can safely be used as shell command arguments.
+func QuoteCommand(args []string) string {
+	var l []string
+	for _, s := range args {
+		l = append(l, Quote(s))
+	}
+	return strings.Join(l, " ")
+}

--- a/shellescape_test.go
+++ b/shellescape_test.go
@@ -53,3 +53,9 @@ func TestCleanString(t *testing.T) {
 	expected := `foo.example.com`
 	assertEqual(t, s, expected)
 }
+
+func TestQuoteCommand(t *testing.T) {
+	s := shellescape.QuoteCommand([]string{"ls", "-l", "file with space"})
+	expected := `ls -l 'file with space'`
+	assertEqual(t, s, expected)
+}


### PR DESCRIPTION
* adds support for quoting a complete command comprised of a program
name and arguments