### PR TITLE
escargs: add -D flag

### DIFF
--- a/cmd/escargs/escargs.go
+++ b/cmd/escargs/escargs.go
@@ -5,23 +5,35 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"os"
 
 	"github.com/alessio/shellescape"
 )
 
+var (
+	flagDiscardBlankLines = flag.Bool("D", false, "ignore blank lines on the standard input.")
+)
+
 func main() {
+	flag.Parse()
+
 	firstScan := true
 	scanner := bufio.NewScanner(os.Stdin)
 
 	for scanner.Scan() {
+		line := scanner.Text()
+		if *flagDiscardBlankLines && len(line) == 0 {
+			continue
+		}
+
 		if firstScan {
 			firstScan = false
 		} else {
 			fmt.Printf(" ")
 		}
 
-		fmt.Printf("%s", shellescape.Quote(scanner.Text()))
+		fmt.Printf("%s", shellescape.Quote(line))
 	}
 }


### PR DESCRIPTION
The -D flag emulates xargs's default behaviour of ignoring
blank lines on standard input.