### PR TITLE
add StripUnsafe()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 .idea/
+
+escargs

--- a/shellescape.go
+++ b/shellescape.go
@@ -17,6 +17,7 @@ be appended to/used in the context of shell programs' command line arguments.
 import (
 	"regexp"
 	"strings"
+	"unicode"
 )
 
 var pattern *regexp.Regexp
@@ -49,4 +50,17 @@ func QuoteCommand(args []string) string {
 	}
 
 	return strings.Join(l, " ")
+}
+
+// StripUnsafe remove non-printable runes, e.g. control characters in
+// a string that is meant  for consumption by terminals that support
+// control characters.
+func StripUnsafe(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) {
+			return r
+		}
+
+		return -1
+	}, s)
 }

--- a/shellescape_test.go
+++ b/shellescape_test.go
@@ -59,3 +59,24 @@ func TestQuoteCommand(t *testing.T) {
 	expected := `ls -l 'file with space'`
 	assertEqual(t, s, expected)
 }
+
+func TestStripUnsafe(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"all ASCII printable characters", args{`"printable!" characters '' 12321312"`}, `"printable!" characters '' 12321312"`},
+		{"some non printable characters", args{"print\u0081ble"}, "printble"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shellescape.StripUnsafe(tt.args.s); got != tt.want {
+				t.Errorf("StripUnsafe() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
StripUnsafe remove non-printable runes, e.g. control characters in
a string that is meant  for consumption by terminals that support
control characters.