### PR TITLE
fix imports

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/cmd/escargs/escargs.go
+++ b/cmd/escargs/escargs.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/alessio/shellescape"
+	"al.essio.dev/pkg/shellescape"
 )
 
 var (
@@ -113,5 +113,5 @@ Options:`
 
 func outputVersion() {
 	fmt.Fprintf(os.Stderr, "escargs version %s\n", version)
-	fmt.Fprintln(os.Stderr, "Copyright (C) 2020-2023 Alessio Treglia <alessio@debian.org>")
+	fmt.Fprintln(os.Stderr, "Copyright (C) 2020-2024 Alessio Treglia <alessio@debian.org>")
 }

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alessio/shellescape"
+	"al.essio.dev/pkg/shellescape"
 	"github.com/google/shlex"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alessio/shellescape
+module al.essio.dev/pkg/shellescape
 
 go 1.18
 

--- a/shellescape.go
+++ b/shellescape.go
@@ -6,7 +6,7 @@ POSIX shells.
 The original Python package which this work was inspired by can be found
 at https://pypi.python.org/pypi/shellescape.
 */
-package shellescape // "import gopkg.in/alessio/shellescape.v1"
+package shellescape // "import al.essio.dev/pkg/shellescape"
 
 /*
 The functionality provided by shellescape.Quote could be helpful

--- a/shellescape_test.go
+++ b/shellescape_test.go
@@ -3,7 +3,7 @@ package shellescape_test
 import (
 	"testing"
 
-	"github.com/alessio/shellescape"
+	"al.essio.dev/pkg/shellescape"
 )
 
 func assertEqual(t *testing.T, s, expected string) {


### PR DESCRIPTION
Fixes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded support for Go versions, now including `1.22.x`.
  
- **Bug Fixes**
	- Updated package import paths for `shellescape` to reflect new hosting, ensuring compatibility.

- **Chores**
	- Updated copyright year in relevant files to 2024.
	- Renamed Go module path for better organization and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->