### PR TITLE
README: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ func main() {
 _[See in Go Playground](https://go.dev/play/p/GeguukpSUTk)_
 
 ## The escargs utility
-__escargs__ reads lines from the standard input and prints shell-escaped versions. Unlinke __xargs__, blank lines on the standard input are not discarded.
+__escargs__ reads lines from the standard input and prints shell-escaped versions. Unlike __xargs__, blank lines on the standard input are not discarded.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typographical error in the `README.md` for the `shellescape` package, enhancing clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->