### PR TITLE
Fix ExampleQuoteCommand

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -79,6 +79,7 @@ func ExampleQuoteCommand() {
 	fmt.Println("lastSplit[1]:", lastSplit[1])
 	fmt.Println("lastSplit[2]:", lastSplit[2])
 
+	// Output:
 	// unsafe: ls -l myfile; rm -rf /
 	// command: ls -l 'myfile; rm -rf /'
 	// splitCommand: [ls -l myfile; rm -rf /]


### PR DESCRIPTION
This PR adds `// Output:` to the `ExampleQuoteCommand`, so this example becomes available on pkg.go.dev.

Before:

<img width="285" alt="image" src="https://github.com/user-attachments/assets/061b023f-ea6f-4fcb-975a-40eb4b0a07f2">

After:

<img width="317" alt="image" src="https://github.com/user-attachments/assets/f21027e7-8897-417d-be93-5d83887e2a64">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved clarity of test output by adding a comment marker for expected results in the `ExampleQuoteCommand` function.
  
- **Documentation**
	- Enhanced documentation within the test file for better understanding of expected outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->