### PR TITLE
golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,11 +41,6 @@ issues:
     - text: "ST1003:"
       linters:
         - stylecheck
-    # FIXME: Disabled until golangci-lint updates stylecheck with this fix:
-    # https://github.com/dominikh/go-tools/issues/389
-    - text: "ST1016:"
-      linters:
-        - stylecheck
 
 linters-settings:
   dogsled:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,10 +41,11 @@ issues:
     - text: "ST1003:"
       linters:
         - stylecheck
+    - path: "_test.go"
+      linters:
+        - wsl
 
 linters-settings:
   dogsled:
     max-blank-identifiers: 3
 
-run:
-  tests: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - goconst
     - gocritic
@@ -17,7 +18,6 @@ linters:
     - ineffassign
     - misspell
     - prealloc
-    - exportloopref
     - revive
     - staticcheck
     - stylecheck
@@ -25,7 +25,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - misspell
     - wsl
 
 issues:
@@ -51,9 +50,6 @@ issues:
 linters-settings:
   dogsled:
     max-blank-identifiers: 3
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
 
 run:
   tests: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - staticcheck
     - stylecheck
     - typecheck
+    - thelper
     - unconvert
     - unparam
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - bodyclose
     - copyloopvar
     - dogsled
+    - gci
     - goconst
     - gocritic
     - gofmt
@@ -49,4 +50,12 @@ issues:
 linters-settings:
   dogsled:
     max-blank-identifiers: 3
-
+  # define the import orders
+  gci:
+    sections:
+      # Standard section: captures all standard packages.
+      - standard
+      # Default section: catchall that is not standard or custom
+      - default
+      # linters that related to local tool, so they should be separated
+      - localmodule

--- a/example_test.go
+++ b/example_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"al.essio.dev/pkg/shellescape"
 	"github.com/google/shlex"
+
+	"al.essio.dev/pkg/shellescape"
 )
 
 func ExampleQuote() {

--- a/shellescape_test.go
+++ b/shellescape_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func assertEqual(t *testing.T, s, expected string) {
+	t.Helper()
+
 	if s != expected {
 		t.Fatalf("%q (expected: %q)", s, expected)
 	}


### PR DESCRIPTION
- **fix enabled golangci-lint linters**
- **Remove exclusion added years ago**
- **enable golangci-lint on test files**
- **Enable thelper linter via golangci-lint**
- **Enable gci linter via golangci-lint**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced linting capabilities with the addition of new linters: `copyloopvar`, `gci`, and `thelper`.
	- Improved organization of import statements in test files for better readability.
- **Bug Fixes**
	- Adjusted linter settings to exclude specific rules for test files, improving linting accuracy.
- **Tests**
	- Marked `assertEqual` function as a test helper to improve error reporting in test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->