### PR TITLE
Refresh Go toolchain

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,16 @@ jobs:
     - name: Build
       run: go build -v ./...
     - name: Test
+      run: go test -race ./...
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: 'stable'
+    - name: Coverage
       run: go test -race -cover -covermode=atomic -coverprofile=coverage.out ./...
     - uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x, 1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
add go 1.24, remove go 1.20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated our automation configuration to support the latest runtime versions.
- **Tests**
  - Introduced enhanced testing with code coverage analysis and race detection to improve quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->