### PR TITLE
Potential fix for code scanning alert no. 53: Log entries created from user input

### DIFF
--- a/cmd/escargs/escargs.go
+++ b/cmd/escargs/escargs.go
@@ -77,7 +77,8 @@ func main() {
 			fmt.Printf(" ")
 		}
 
-		fmt.Printf("%s", shellescape.Quote(line))
+		safeLine := shellescape.StripUnsafe(line)
+		fmt.Printf("%s", shellescape.Quote(safeLine))
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/alessio/shellescape/security/code-scanning/53](https://github.com/alessio/shellescape/security/code-scanning/53)

General fix: sanitize untrusted input before writing it to output that may be interpreted as log/terminal text. For plain-text safety, remove control characters (including CR/LF and terminal escapes) prior to formatting.

Best fix here: in `cmd/escargs/escargs.go`, sanitize `line` with `shellescape.StripUnsafe` before passing it to `shellescape.Quote`. This preserves the intended feature (shell-escaping arguments) while preventing control-character-based forging/confusion. No new imports or dependencies are needed because `StripUnsafe` already exists in `shellescape.go`.

Change needed:
- **File:** `cmd/escargs/escargs.go`
- **Region:** loop in `main()` around line 80.
- Replace `fmt.Printf("%s", shellescape.Quote(line))` with output based on a sanitized variable, e.g.:
  - `safeLine := shellescape.StripUnsafe(line)`
  - `fmt.Printf("%s", shellescape.Quote(safeLine))`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
