### PR TITLE
escargs: report a scan error instead of silently truncating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ _testmain.go
 
 .idea/
 
-escargs
+/escargs
 
 config.hcl
 

--- a/cmd/escargs/escargs.go
+++ b/cmd/escargs/escargs.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -49,8 +50,7 @@ func main() {
 		return
 	}
 
-	firstScan := true
-	scanner := bufio.NewScanner(os.Stdin)
+	var input io.Reader = os.Stdin
 
 	if argFile != "" {
 		f, err := os.Open(argFile)
@@ -58,8 +58,19 @@ func main() {
 			log.Fatal(err)
 		}
 
-		scanner = bufio.NewScanner(f)
+		input = f
 	}
+
+	if err := escape(os.Stdout, input); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// escape writes the shell-escaped items read from r to w, separated by
+// spaces.
+func escape(w io.Writer, r io.Reader) error {
+	firstScan := true
+	scanner := bufio.NewScanner(r)
 
 	if nullSeparator {
 		scanner.Split(shellescape.ScanTokens)
@@ -74,11 +85,14 @@ func main() {
 		if firstScan {
 			firstScan = false
 		} else {
-			fmt.Printf(" ")
+			_, _ = fmt.Fprint(w, " ")
 		}
 
-		fmt.Printf("%s", shellescape.Quote(line))
+		_, _ = fmt.Fprint(w, shellescape.Quote(line))
 	}
+
+	// A scan error stops the loop early and truncates the output.
+	return scanner.Err()
 }
 
 func usage() {

--- a/cmd/escargs/escargs_test.go
+++ b/cmd/escargs/escargs_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestEscape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr error
+	}{
+		{
+			name:  "quotes each item",
+			input: "hello world\nsafe\n",
+			want:  "'hello world' safe",
+		},
+		{
+			name:  "no input",
+			input: "",
+			want:  "",
+		},
+		{
+			name:    "item longer than the scanner buffer",
+			input:   strings.Repeat("a", bufio.MaxScanTokenSize) + "\nsafe\n",
+			want:    "",
+			wantErr: bufio.ErrTooLong,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			err := escape(&buf, strings.NewReader(tt.input))
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("escape() error = %v, want %v", err, tt.wantErr)
+			}
+
+			if got := buf.String(); got != tt.want {
+				t.Errorf("escape() wrote %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`escargs` never reads `scanner.Err()`, so a scan error looks like end of input.

`bufio.Scanner` stops and records `bufio.ErrTooLong` on an item at or above
`bufio.MaxScanTokenSize` (64 KiB). The loop in `main` ends, the process exits 0, and the
items already written are the whole output. When the oversized item comes first, nothing
is written at all:

```
$ { head -c 65536 /dev/zero | tr '\0' 'a'; echo; echo safe1; echo safe2; } | escargs; echo "exit=$?"
exit=0
```

`xargs`, which `escargs` is modelled on, fails loudly on the same shape:

```
xargs: argument line too long   (exit 1)
```

This matters more here than in a typical filter: the output is meant to be substituted into
a shell command line, so a silently shortened argument list is a command that runs with the
wrong arguments and a success status.

### The repo already treats this as an error everywhere else

- `fuzz_test.go:248` raises the cap with `scanner.Buffer`, and `fuzz_test.go:256` treats
  `scanner.Err() != nil` as `t.Fatalf` - the test harness knows about both the 64 KiB limit
  and the error.
- `cmd/escargs/escargs.go` already routes its other error source, `os.Open` for `-a`,
  through `log.Fatal`.
- `.agents/rules/code-style.md`, under Error Handling: *"Never ignore returned errors
  silently unless explicitly documented"*, and CLI errors go through `log.Fatal` with the
  `escargs: ` prefix - which is what this change does.

### The change

`main` is not testable as it stands, so the scan loop moves into `escape(w io.Writer, r
io.Reader) error`, which ends with `return scanner.Err()`. `main` reports it through the
existing `log.Fatal` path. Reading and writing behaviour is otherwise unchanged - the writes
keep the same `_, _ =` treatment used by `usage()`.

```
$ { head -c 65536 /dev/zero | tr '\0' 'a'; echo; echo safe1; } | escargs; echo "exit=$?"
escargs: bufio.Scanner: token too long
exit=1
```

Normal input is byte-identical before and after.

I did not raise the scanner buffer. Failing loudly matches `xargs` and keeps the memory
policy your call; a `scanner.Buffer` bump can follow separately if you want oversized items
to pass through.

### Test

`cmd/escargs/escargs_test.go` is new - table-driven with `t.Parallel()`, per
`.agents/rules/testing-benchmarks.md`. Reverting only `return scanner.Err()` to `return nil`:

```
--- FAIL: TestEscape/item_longer_than_the_scanner_buffer
    escargs_test.go:47: escape() error = <nil>, want bufio.Scanner: token too long
```

`go test -race ./...` passes on both packages, `go vet` and `gofmt` are clean.

### One incidental change

`.gitignore` line 28 was `escargs`, which has no slash and so matches the `cmd/escargs`
**directory**, not just the built binary - any new file added there is ignored. Anchoring it
to `/escargs` keeps the root binary ignored (`make escargs` and `make clean` both use the
root path) and lets the test file be tracked.

---

Disclosure: this was found and prepared with AI assistance (Claude). The failing input, the
red-green check, and the full `go test -race ./...` run were executed locally.
